### PR TITLE
#9 Resizing should be skipped when a Blob is not decorated with Chief2moro.ImageDataExtensions attributes

### DIFF
--- a/src/Chief2moro.ImageDataExtensions/ImageResizeContentEvents.cs
+++ b/src/Chief2moro.ImageDataExtensions/ImageResizeContentEvents.cs
@@ -2,7 +2,6 @@
 using System.Reflection;
 using EPiServer;
 using EPiServer.Core;
-using EPiServer.Core.Internal;
 using EPiServer.DataAnnotations;
 using EPiServer.Framework.Blobs;
 using EPiServer.ServiceLocation;

--- a/src/Chief2moro.ImageDataExtensions/Properties/AssemblyInfo.cs
+++ b/src/Chief2moro.ImageDataExtensions/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]


### PR DESCRIPTION
Otherwise, ex. SVG file upload fails